### PR TITLE
parse sing-box `processPath` into `process`

### DIFF
--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -29,6 +29,7 @@ export type ConnectionItem = {
     destinationPort: string;
     host: string;
     process?: string;
+    processPath?: string;
     sniffHost?: string;
   };
   upload: number;
@@ -50,6 +51,14 @@ function appendData(s: string) {
   let o: ConnectionsData;
   try {
     o = JSON.parse(s);
+    o.connections.forEach(conn => {
+      let m = conn.metadata;
+      if (m.process == null) {
+        if (m.processPath != null) {
+          m.process = m.processPath.replace(/^.*[/\\](.*)$/, "$1");
+        }
+      }
+    });
   } catch (err) {
     // eslint-disable-next-line no-console
     console.log('JSON.parse error', JSON.parse(s));


### PR DESCRIPTION
clash-api for sing-box use `processPath` field which is the full-path of the captured process.
- On Windows: `\Device\HarddiskVolume3\Path\To\Program.exe`
- On Linux: `/path/to/program (username)`

grab the last part of the full path and render as `process`.