### PR TITLE
fix i18next warn

### DIFF
--- a/src/misc/i18n.ts
+++ b/src/misc/i18n.ts
@@ -52,6 +52,7 @@ i18next
       },
     },
     supportedLngs: ['zh-CN', 'zh-TW', 'en'],
+    load: 'currentOnly',
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
fix i18next::languageUtils: rejecting language code not found in supportedLngs: zh