### PR TITLE
fix: avoid errors in browser console

### DIFF
--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -51,11 +51,11 @@ function appendData(s: string) {
   let o: ConnectionsData;
   try {
     o = JSON.parse(s);
-    o.connections.forEach(conn => {
-      let m = conn.metadata;
+    o.connections?.forEach((conn) => {
+      const m = conn.metadata;
       if (m.process == null) {
         if (m.processPath != null) {
-          m.process = m.processPath.replace(/^.*[/\\](.*)$/, "$1");
+          m.process = m.processPath.replace(/^.*[/\\](.*)$/, '$1');
         }
       }
     });
@@ -86,12 +86,12 @@ export function fetchData(
   const ws = new WebSocket(url);
   ws.addEventListener('error', () => {
     wsState = 3;
-    subscribers.forEach((s) => s.onClose());
+    subscribers.forEach((s) => s.onClose?.());
     subscribers.length = 0;
   });
   ws.addEventListener('close', () => {
     wsState = 3;
-    subscribers.forEach((s) => s.onClose());
+    subscribers.forEach((s) => s.onClose?.());
     subscribers.length = 0;
   });
   ws.addEventListener('message', (event) => appendData(event.data));

--- a/src/components/APIConfig.tsx
+++ b/src/components/APIConfig.tsx
@@ -86,11 +86,13 @@ function APIConfig({ dispatch }) {
   const detectApiServer = async () => {
     // if there is already a clash API server at `/`, just use it as default value
     const res = await fetch('/');
-    res.json().then((data) => {
-      if (data['hello'] === 'clash') {
-        setBaseURL(window.location.origin);
-      }
-    });
+    if (res.headers.get('content-type')?.includes('application/json')) {
+      res.json().then((data) => {
+        if (data['hello'] === 'clash') {
+          setBaseURL(window.location.origin);
+        }
+      });
+    }
   };
   useEffect(() => {
     detectApiServer();

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -313,9 +313,10 @@ function Conn({ apiConfig }) {
     ({ connections }) => {
       const prevConnsKv = arrayToIdKv(prevConnsRef.current);
       const now = Date.now();
-      const x = connections.map((c: ConnectionItem) =>
-        formatConnectionDataItem(c, prevConnsKv, now, sourceMap)
-      );
+      const x =
+        connections?.map((c: ConnectionItem) =>
+          formatConnectionDataItem(c, prevConnsKv, now, sourceMap)
+        ) ?? [];
       const closed = [];
       for (const c of prevConnsRef.current) {
         const idx = x.findIndex((conn: ConnectionItem) => conn.id === c.id);

--- a/src/components/TrafficNow.tsx
+++ b/src/components/TrafficNow.tsx
@@ -74,7 +74,7 @@ function useConnection(apiConfig) {
       setState({
         upTotal: prettyBytes(uploadTotal),
         dlTotal: prettyBytes(downloadTotal),
-        connNumber: connections.length,
+        connNumber: connections ? connections.length : 0,
         mUsage: prettyBytes(memory),
       });
     },

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -179,7 +179,7 @@ function parseConfigQueryString() {
   const qs = search.replace(/^\?/, '').split('&');
   for (let i = 0; i < qs.length; i++) {
     const [k, v] = qs[i].split('=');
-    collector[k] = encodeURIComponent(v);
+    collector[k] = decodeURIComponent(v);
   }
   return collector;
 }


### PR DESCRIPTION
1. onClose undefined error
2. null value has no length property
3. null value has no map function
4. Parse HTML to json object error
5. `JSON.parse error` exception throwed in `connections.ts`
6. The value in the query parameter is encoded twice

Example of no. 6:

Assume the secret is `123&abc`. When used in the URL, it has already been encoded as 123%26abc. Therefore, decoding should be performed during parsing. However, the current code encodes the encoded value, resulting in %2526, causing the backend to fail to connect and report a 401 error.

<img width="401" alt="image" src="https://github.com/MetaCubeX/Yacd-meta/assets/8395112/f954727a-5ec7-4e82-8fe9-a1dc2a203b52">

<img width="714" alt="image" src="https://github.com/MetaCubeX/Yacd-meta/assets/8395112/8648ff39-3465-4a12-8e75-067460ca92ef">

<img width="726" alt="image" src="https://github.com/MetaCubeX/Yacd-meta/assets/8395112/3cf4bcb9-11bd-4de2-bb81-cfe307df3ba1">

