### PR TITLE
feat: add healthcheck functionality for specified proxy

### DIFF
--- a/src/api/proxies.ts
+++ b/src/api/proxies.ts
@@ -1,4 +1,5 @@
 import { getURLAndInit } from '../misc/request-helper';
+import { ClashAPIConfig } from '../types';
 
 const endpoint = '/proxies';
 
@@ -73,6 +74,21 @@ export async function healthcheckProviderByName(config, name) {
   const options = { ...init, method: 'GET' };
   return await fetch(
     url + '/providers/proxies/' + encodeURIComponent(name) + '/healthcheck',
+    options
+  );
+}
+
+export async function healthcheckProviderProxy(
+  config: ClashAPIConfig,
+  providerName: string,
+  proxyName: string
+) {
+  const { url, init } = getURLAndInit(config);
+  const options = { ...init, method: 'GET' };
+  return await fetch(
+    `${url}/providers/proxies/${encodeURIComponent(providerName)}/${encodeURIComponent(
+      proxyName
+    )}/healthcheck`,
     options
   );
 }

--- a/src/components/proxies/ProxyLatency.module.scss
+++ b/src/components/proxies/ProxyLatency.module.scss
@@ -1,10 +1,54 @@
 @import '~/styles/utils/custom-media';
 
 .proxyLatency {
-  border-radius: 20px;
-  color: #eee;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 50px;
+  padding: 4px 10px;
+  gap: 4px;
+  border-radius: 9999px;
+  border: 1px solid var(--color-proxy-border);
+  background: var(--bg-near-transparent);
+  color: var(--color-text);
   font-size: 0.75em;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease,
+    color 0.15s ease, transform 0.15s ease;
+  user-select: none;
+  outline: none;
   @media (--breakpoint-not-small) {
+    padding: 5px 12px;
     font-size: 0.8em;
+  }
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:hover,
+.clickable:focus-visible {
+  background: var(--color-bg-proxy);
+  border-color: var(--card-hover-border-lightness);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.placeholder {
+  color: var(--color-text-secondary);
+}
+
+.testing {
+  animation: proxyLatencyPulse 1s ease-in-out infinite;
+}
+
+@keyframes proxyLatencyPulse {
+  0% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.8;
   }
 }

--- a/src/components/proxies/ProxyLatency.tsx
+++ b/src/components/proxies/ProxyLatency.tsx
@@ -1,16 +1,59 @@
+import cx from 'clsx';
 import * as React from 'react';
 
 import s0 from './ProxyLatency.module.scss';
 
 type ProxyLatencyProps = {
-  number: number;
+  number?: number;
   color: string;
+  isTesting?: boolean;
+  error?: string;
+  onClick?: () => void;
 };
 
-export function ProxyLatency({ number, color }: ProxyLatencyProps) {
+export function ProxyLatency({ number, color, isTesting, error, onClick }: ProxyLatencyProps) {
+  const hasNumber = typeof number === 'number';
+  const label = isTesting ? 'Testing...' : hasNumber ? `${number} ms` : error || '--';
+
+  const className = cx(s0.proxyLatency, {
+    [s0.clickable]: Boolean(onClick),
+    [s0.placeholder]: !hasNumber || Boolean(error),
+    [s0.testing]: isTesting,
+  });
+
+  const handleClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (!onClick || isTesting) return;
+      e.preventDefault();
+      e.stopPropagation();
+      onClick();
+    },
+    [isTesting, onClick]
+  );
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!onClick || isTesting) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      }
+    },
+    [isTesting, onClick]
+  );
+
   return (
-    <span className={s0.proxyLatency} style={{ color }}>
-      <span>{number} ms</span>
+    <span
+      className={className}
+      style={{ color: hasNumber ? color : undefined }}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      title={label}
+    >
+      <span>{label}</span>
     </span>
   );
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -62,11 +62,15 @@ export type ProxyItem = {
   xudp?: boolean;
   tfo: boolean;
   history: LatencyHistory;
+  providerName?: string;
   all?: string[];
   now?: string;
 };
 export type ProxiesMapping = Record<string, ProxyItem>;
-export type DelayMapping = Record<string, { number?: number }>;
+export type DelayMapping = Record<
+  string,
+  { number?: number; error?: string; testing?: boolean; updatedAt?: number }
+>;
 
 export type ProxyProvider = {
   name: string;


### PR DESCRIPTION
## What’s this PR about?

This PR adds support for **manual single-proxy latency testing** 
https://github.com/MetaCubeX/Yacd-meta/issues/99

Users can now click the latency display area of a node to trigger a healthcheck for that specific proxy, without waiting for
global checks.

## Key points

- Clickable latency display area
- Text placeholder for timeout / no-result state (still clickable)
- Does not affect existing auto / batch healthcheck logic

## Demo

A live demo is available here (Cloudflare Pages):
https://yacd.olivi.top

## Reference

API doc:
https://wiki.metacubex.one/api/?h=#providersproxiesproviders_nameproxies_namehealthcheck

## Notes

- Changes are UI-only and scoped to a single feature
- Happy to adjust implementation or UX based on review feedback
