### PR TITLE
fix: 修复图标对齐的问题

### DIFF
--- a/src/components/SideBar.module.scss
+++ b/src/components/SideBar.module.scss
@@ -106,6 +106,10 @@
   bottom: 10px;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 @media (max-width: 768px) {

--- a/src/components/shared/ThemeSwitcher.module.scss
+++ b/src/components/shared/ThemeSwitcher.module.scss
@@ -24,6 +24,8 @@
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: var(--sz);
   height: var(--sz);
   select {
     cursor: pointer;


### PR DESCRIPTION
fix #104 

before:
<img width="257" height="225" alt="image" src="https://github.com/user-attachments/assets/a75f7753-7b5c-42b9-bd7e-e0c65be01c20" />
after:
<img width="257" height="225" alt="image" src="https://github.com/user-attachments/assets/c49a19ee-6450-4829-bf95-505085ed8efd" />

