### PR TITLE
chore: Adapt the `hidden` field for proxy groups

### DIFF
--- a/src/store/proxies.tsx
+++ b/src/store/proxies.tsx
@@ -388,7 +388,9 @@ function retrieveGroupNamesFrom(proxies: Record<string, ProxyItem>) {
   for (const prop in proxies) {
     const p = proxies[prop];
     if (p.all && Array.isArray(p.all)) {
-      groupNames.push(prop);
+      if (!p.hidden) {
+        groupNames.push(prop);
+      }
       if (prop === 'GLOBAL') {
         globalAll = Array.from(p.all);
       }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -66,6 +66,7 @@ export type ProxyItem = {
   providerName?: string;
   all?: string[];
   now?: string;
+  hidden?: boolean;
 };
 export type ProxiesMapping = Record<string, ProxyItem>;
 export type DelayMapping = Record<


### PR DESCRIPTION
Adapts to the `hidden` field in policy groups, the GUI does not display proxy groups tags where `hidden: true`.