### PR TITLE
fix: encode the group name when switching a proxy

### DIFF
--- a/src/api/proxies.ts
+++ b/src/api/proxies.ts
@@ -33,7 +33,7 @@ export async function fetchProxies(config) {
 export async function requestToSwitchProxy(apiConfig, name1, name2) {
   const body = { name: name2 };
   const { url, init } = getURLAndInit(apiConfig);
-  const fullURL = `${url}${endpoint}/${name1}`;
+  const fullURL = `${url}${endpoint}/${encodeURIComponent(name1)}`;
   return await fetch(fullURL, {
     ...init,
     method: 'PUT',


### PR DESCRIPTION
Selecting a proxy inside a group silently does nothing when the group name contains URL metacharacters.

`requestToSwitchProxy` is the only request in `src/api/proxies.ts` that interpolates the name into the path without encoding it:

```js
const fullURL = `${url}${endpoint}/${name1}`;
```

Every other request in the same file encodes it — `requestDelayForProxy`, `requestDelayForProxyGroup`, the provider endpoints, `updateProviderByName` and so on.

### Why it matters

Group names are free-form and backends do produce names with metacharacters. sing-box tags outbounds like `section/Group #1`:

* the `/` turns one path segment into two, so the `/proxies/{name}` route no longer matches;
* everything after `#` is parsed as a fragment by the browser and is never sent.

The PUT therefore addresses a different, nonexistent proxy. The backend answers 404, the switch does not happen, and the UI snaps back to the previous value on the next `fetchProxies`. Nothing in the interface indicates that anything went wrong.

### The change

```diff
-  const fullURL = `${url}${endpoint}/${name1}`;
+  const fullURL = `${url}${endpoint}/${encodeURIComponent(name1)}`;
```

Plain names are left byte for byte unchanged, so nothing regresses for the common case. The single caller, `switchProxyImpl` in `src/store/proxies.tsx`, passes the raw name straight from the `/proxies` payload, so there is no double encoding.

Verified against a sing-box backend: with the encoded path the same request returns 204 and both `now` and `fixed` move to the selected member, while the unencoded path resolves to a different proxy.